### PR TITLE
Added check to avoid kit DLLs being loaded if a same-named one's already loaded

### DIFF
--- a/SpeckleCore/AssemblyCatalogue.cs
+++ b/SpeckleCore/AssemblyCatalogue.cs
@@ -64,7 +64,7 @@ namespace SpeckleCore
       var loadedSpeckleReferencingAssemblyNames = loadedAssemblies.Select( assembly => assembly.GetName() ).ToArray();
       var directories = Directory.GetDirectories( SpeckleKitsDirectory );
       var currDomain = AppDomain.CurrentDomain;
-
+      var previouslyLoadedAssemblyNames = AppDomain.CurrentDomain.GetAssemblies().Select(a => a.GetName().Name);
 
       foreach ( var directory in directories )
       {
@@ -72,7 +72,7 @@ namespace SpeckleCore
         {
           var unloadedAssemblyName = SafeGetAssemblyName( assemblyPath );
 
-          if ( unloadedAssemblyName == null )
+          if ( unloadedAssemblyName == null || previouslyLoadedAssemblyNames.Contains(unloadedAssemblyName.Name))
           {
             continue;
           }


### PR DESCRIPTION
There is one library called SpeckleGSAInterfaces.dll that I publish as part of the SpeckleStructural kit (i.e. it's present in the %localappdata%/SpeckleKits/SpeckleStructural directory) which SpeckleGSA also loads.  
The reason I can't remove it is due to other apps using the kit (namely Revit) who use the conversion routines in the kit but don't have the SpeckleGSAInterfaces.dll loaded.
As far as I understand, what should happen with the .NET framework is that no two libraries with the same name are loaded into the app domain, but for a reason I haven't gotten to the bottom of yet, this is indeed happening.  It's an apparently intermittent problem - with no definitive solution that sticks in my head - and isn't present in the last SpeckleWorks versions of the repos.
I'd like to move towards removing this library entirely and in the meantime, I'm happy for any of you to investigate and help me see a solution I can't see yet, but I thought this would be a harmless change to Core that would avoid this.